### PR TITLE
prepare to rename feedstock fenics-ffcx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About fenics-ffcx-ufcx
-======================
+About fenics-ffcx
+=================
 
 Home: https://fenicsproject.org
 
@@ -44,10 +44,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-fenics--ffcx-green.svg)](https://anaconda.org/conda-forge/fenics-ffcx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fenics-ffcx.svg)](https://anaconda.org/conda-forge/fenics-ffcx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fenics-ffcx.svg)](https://anaconda.org/conda-forge/fenics-ffcx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fenics-ffcx.svg)](https://anaconda.org/conda-forge/fenics-ffcx) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-fenics--ufcx-green.svg)](https://anaconda.org/conda-forge/fenics-ufcx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/fenics-ufcx.svg)](https://anaconda.org/conda-forge/fenics-ufcx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/fenics-ufcx.svg)](https://anaconda.org/conda-forge/fenics-ufcx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/fenics-ufcx.svg)](https://anaconda.org/conda-forge/fenics-ufcx) |
 
-Installing fenics-ffcx-ufcx
-===========================
+Installing fenics-ffcx
+======================
 
-Installing `fenics-ffcx-ufcx` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `fenics-ffcx` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -133,17 +133,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating fenics-ffcx-ufcx-feedstock
-===================================
+Updating fenics-ffcx-feedstock
+==============================
 
-If you would like to improve the fenics-ffcx-ufcx recipe or build a new
+If you would like to improve the fenics-ffcx recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/fenics-ffcx-ufcx-feedstock are
+Note that all branches in the conda-forge/fenics-ffcx-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,5 +87,6 @@ about:
   dev_url: https://github.com/fenics/ffcx
 
 extra:
+  feedstock-name: fenics-ffcx
   recipe-maintainers:
     - minrk


### PR DESCRIPTION
this should have been the name, but I didn't know about the metadata when it was merged

I'll merge this and rename the repo once feedstock-outputs has been updated